### PR TITLE
Fix an example in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ package main
 import "github.com/felixge/fgtrace"
 
 func main() {
-	defer fgtrace.Config{Dst: fgtrace.File("fgtrace.json")}.Start().Stop()
+	defer fgtrace.Config{Dst: fgtrace.File("fgtrace.json")}.Trace().Stop()
 
 	// <code to trace>
 }


### PR DESCRIPTION
Right at the beginning of the documentation, in the [Quick Start section](https://github.com/felixge/fgtrace#quick-start), the one-liner is described as:

```go
package main

import "github.com/felixge/fgtrace"

func main() {
	defer fgtrace.Config{Dst: fgtrace.File("fgtrace.json")}.Start().Stop()

	// <code to trace>
}
```

However, from local environment and browsing the source it seems that `Start` should be `Trace`. That means that the snippet should read:

```go
package main

import "github.com/felixge/fgtrace"

func main() {
	defer fgtrace.Config{Dst: fgtrace.File("fgtrace.json")}.Trace().Stop()

	// <code to trace>
}
```

With that change I was able not only to compile and run, but to generate a trace file and display it in Perfetto.

EDIT: the diff shows the last line has also changed... that's caused by my IDE inserting a newline at the end. I have no idea if that's proper or not.